### PR TITLE
Stop probing ISAs after archive with matching arch is found

### DIFF
--- a/runtime/src/loader.cpp
+++ b/runtime/src/loader.cpp
@@ -455,16 +455,15 @@ kpack_error_t kpack_load_code_object(kpack_cache_t cache,
       KPACK_DEBUG(cache, "  found kernel: %zu bytes", kernel_size);
       break;
     }
-    if (err != KPACK_ERROR_KERNEL_NOT_FOUND) {
-      // Unexpected error
-      KPACK_DEBUG(cache, "  error getting kernel: %d", err);
-      return err;
-    }
-    KPACK_DEBUG(cache, "  kernel not found in this archive");
+    // Archive was found with matching architecture — the kernel either
+    // exists or it doesn't. Trying a different ISA won't help, so return
+    // the error directly (KERNEL_NOT_FOUND or unexpected error).
+    KPACK_DEBUG(cache, "  kernel not found in this archive (error %d)", err);
+    return err;
   }
 
   if (!kernel_data) {
-    KPACK_DEBUG(cache, "no matching architecture found in any archive");
+    KPACK_DEBUG(cache, "no archive with compatible architecture found");
     return KPACK_ERROR_ARCH_NOT_FOUND;
   }
 


### PR DESCRIPTION
## Summary
- When `kpack_get_kernel()` fails with `KPACK_ERROR_KERNEL_NOT_FOUND` after finding a matching archive+arch, the loader now returns immediately instead of falling through to probe the next ISA (e.g., `gfx9-4-generic`)
- The previous behavior produced misleading "no matching architecture found" errors and wasted time probing archives that can't help

## Evidence
CI log for rocblas showed:
```
kpack: opened and cached archive: .../blas_lib_gfx942.kpack
kpack:   architecture: gfx942
kpack:   kernel not found in this archive          <-- should stop here
kpack: trying architecture: gfx9-4-generic         <-- wrong: kept probing
kpack: no matching architecture found in any archive
```

The kernel (`#45`) wasn't in the archive due to the multi-CCOB bug (PR #10). But regardless, once we match an archive and architecture, the result is definitive.

## Test plan
- [x] New test `LoadCodeObject_KernelNotFound`: archive found, arch matches, but `co_index=999` not in TOC → `KPACK_ERROR_KERNEL_NOT_FOUND`
- [x] 101/101 CTest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)